### PR TITLE
No need to check for error on form page

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ if ( !$v->passed() ) {
  <label>Name :
       <input type="text" name="name">
  </label>
- <?= Validator::error('name') ? Validator::error('name') : ""; ?>
+ <?=  Validator::error('name'); ?>
 ```
 
 you can wrap error messages with custom HTML markup

--- a/src/azi/Validator.php
+++ b/src/azi/Validator.php
@@ -203,7 +203,7 @@ class Validator {
             return $message;
         }
 
-        return false;
+        return "";
     }
 
 


### PR DESCRIPTION
checking for errors on form page like this `<?= Validator::error('name') ? Validator::error('name') : ""; ?>` is not necessary . this will make the HTML code rushy. 

i have changed the `Validator::error()` to return empty string if no errors found . that way we only have to call error method instead of checking for errors first. 
 now `<?= Validator::error('name'); ?>` will return the error message if there was an error otherwise empty string.

hope you will marge this pull request. 
