### PR TITLE
fix error in Min and Max rules

### DIFF
--- a/src/azi/Rules/MaxRule.php
+++ b/src/azi/Rules/MaxRule.php
@@ -45,7 +45,7 @@ class MaxRule implements RuleInterface
         $this->field   = $field;
         $this->message = $message;
         if ( $this->length ) {
-            if ( strlen( $value ) < $this->length ) {
+            if ( strlen( $value ) <= $this->length ) {
                 return true;
             }
         } else {

--- a/src/azi/Rules/MinRule.php
+++ b/src/azi/Rules/MinRule.php
@@ -42,7 +42,7 @@ class MinRule implements RuleInterface
         $this->field = $field;
         $this->message = $message;
         if($this->length) {
-            if ( strlen( $value ) > $this->length ) {
+            if ( strlen( $value ) >= $this->length ) {
                 return true;
             }
         } else {


### PR DESCRIPTION
when you need validate minimum length of string - one symbol, I think it is more understandable if you set conditional - min:1
